### PR TITLE
fix: wanderweg encoding

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMWanderwegParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMWanderwegParser.java
@@ -25,6 +25,6 @@ public class SCHMWanderwegParser implements TagParser {
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
         String ww_tag = way.getTag("ww");
         boolean value = ww_tag != null && ww_tag.equals("1");
-        wanderwegEnc.setBool(value, edgeId, edgeIntAccess, true);
+        wanderwegEnc.setBool(false, edgeId, edgeIntAccess, value);
     }
 }


### PR DESCRIPTION
the setBool function takes 4 parameters, but the value to encode is the fourth one, not the first ! The first parameter is the `reverse` tag. 
This could be the cause of the avoidance of the ww ways and the differences when we inverse the direction:
- Reverse was true only for ways where `ww` was true
- The `ww` value was always set to true.