### PR TITLE
fix: revert setting values for reverse direction

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMLandParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMLandParser.java
@@ -40,8 +40,11 @@ public class SCHMLandParser implements TagParser {
             return;
         SCHMLand schmLand = SCHMLand.find(schmLandTag);
         if (schmLand != OTHER) {
+            // NOTE: the set is done only for `reverse=false` (1st arg), because SchmLand
+            // does not have the storeTwoDirections set to true. Otherwise, we would need to
+            // call this function again for reverse=true to store the value in the reverse
+            // direction.
             schmLandEnc.setEnum(false, edgeId, edgeIntAccess, schmLand);
-            schmLandEnc.setEnum(true, edgeId, edgeIntAccess, schmLand);
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMObjektartParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMObjektartParser.java
@@ -40,8 +40,12 @@ public class SCHMObjektartParser implements TagParser {
             return;
         SCHMObjektart schmObjektart = SCHMObjektart.find(schmObjektartTag);
         if (schmObjektart != OTHER) {
+            // NOTE: the set is done only for `reverse=false` (1st arg), because
+            // schmObjektart does not have the storeTwoDirections set to true. Otherwise, we
+            // would
+            // need to call this function again for reverse=true to store the value in the
+            // reverse direction.
             schmObjektartEnc.setEnum(false, edgeId, edgeIntAccess, schmObjektart);
-            schmObjektartEnc.setEnum(true, edgeId, edgeIntAccess, schmObjektart);
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMWanderwegParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/SCHMWanderwegParser.java
@@ -5,7 +5,6 @@ import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.storage.IntsRef;
 
-
 /**
  * This parser scans different OSM tags to identify ways where a cyclist has to get off her bike. Like on footway but
  * also in reverse oneway direction.
@@ -25,7 +24,10 @@ public class SCHMWanderwegParser implements TagParser {
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
         String ww_tag = way.getTag("ww");
         boolean value = ww_tag != null && ww_tag.equals("1");
+        // NOTE: the set is done only for `reverse=false` (1st arg), because
+        // SchmWanderweg does not have the storeTwoDirections set to true. Otherwise, we would
+        // need to call this function again for reverse=true to store the value in the
+        // reverse direction.
         wanderwegEnc.setBool(false, edgeId, edgeIntAccess, value);
-        wanderwegEnc.setBool(true, edgeId, edgeIntAccess, value);
     }
 }


### PR DESCRIPTION
As storeTwoDirections is false by default for our custom values, we don't need to call the setBool method for each direction

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
